### PR TITLE
⚡ PlayState의 구조를 개선해 가독성을 높이고, 메소드들의 역할을 명확히 합니다.

### DIFF
--- a/WaktaverseMusic/WaktaverseMusic/Sources/Extension/Extensions.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/Extension/Extensions.swift
@@ -61,6 +61,16 @@ extension Int {
     }
 }
 
+extension Double {
+    func convertTimetoString() -> String {
+        let convertInt = lround(self)-1 >= 0 ? lround(self)-1 : 0
+        let min: String = "\(convertInt/60)".count == 1 ? "0\(convertInt/60):" : "\(convertInt/60):"
+        let sec: String = "\(convertInt%60)".count == 1 ? "0\(convertInt%60)" : "\(convertInt%60)"
+
+        return min+sec
+    }
+}
+
 extension Color {
 
     init(hexcode: String) {

--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -12,19 +12,16 @@ import YouTubePlayerKit
 final class PlayState: ObservableObject {
 
     static let shared = PlayState()
-    @Published var playList: PlayList
+    @Published var playList = PlayList()
     @Published var currentProgress: Double = 0
     @Published var endProgress: Double = 0
     @Published var youTubePlayer = YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false))
-    @Published var isPlaying: YouTubePlayer.PlaybackState // 커스텀이 아닌 실제 State로 변경
+    @Published var isPlaying: YouTubePlayer.PlaybackState  = .unstarted // 재생상태에 따라 변화
     @Published var currentSong: SimpleSong?
 
     var subscription = Set<AnyCancellable>()
 
     init() {
-        self.isPlaying = .unstarted
-        self.playList = PlayList()
-
         youTubePlayer.playbackStatePublisher.sink { [weak self] state in
             guard let self = self else { return }
             if self.isPlaying != state { // 만약 현재상태와 다를 때

--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -15,7 +15,7 @@ final class PlayState: ObservableObject {
     @Published var playList = PlayList()
     @Published var progress = PlayProgress()
     @Published var youTubePlayer = YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false))
-    @Published var isPlaying: YouTubePlayer.PlaybackState  = .unstarted // 재생상태에 따라 변화
+    @Published var isPlaying: YouTubePlayer.PlaybackState  = .unstarted // YouTubePlayer의 재생상태에 따라 변화
     @Published var currentSong: SimpleSong?
 
     var subscription = Set<AnyCancellable>()
@@ -39,6 +39,21 @@ final class PlayState: ObservableObject {
         }.store(in: &subscription)
     }
 
+}
+
+// MARK: YouTubePlayer 컨트롤과 관련된 메소드들을 모아놓은 익스텐션입니다.
+extension PlayState {
+
+    func play() {
+        guard let currentSong = currentSong else { return }
+        self.youTubePlayer.load(source: .url(currentSong.url)) // 바로 load
+    }
+
+    func play(at item: SimpleSong?) {
+        currentSong = item
+        play()
+    }
+
     func forWard() {
         if self.playList.isLast { // 맨 뒤면
             self.playList.currentPlayIndex = 0 // 첫 번째로 이동
@@ -59,18 +74,9 @@ final class PlayState: ObservableObject {
         play()
     }
 
-    func play() {
-        guard let currentSong = currentSong else { return }
-        self.youTubePlayer.load(source: .url(currentSong.url)) // 바로 load
-    }
-
-    func play(at item: SimpleSong?) {
-        currentSong = item
-        play()
-    }
-
 }
 
+// MARK: 커스텀 타입들을 모아놓은 익스텐션입니다.
 extension PlayState {
     public class PlayList: ObservableObject {
         @Published var list: [SimpleSong]

--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -23,13 +23,6 @@ final class PlayState: ObservableObject {
 
     var subscription = Set<AnyCancellable>()
 
-    var nowPlayingSong: SimpleSong? {
-        get {
-            if playList.count == 0 { return nil }
-            return playList[currentPlayIndex]
-        }
-    }
-
     func convertTimetoString(_ dtime: Double) -> String {
         let convertInt = lround(dtime)-1 >= 0 ? lround(dtime)-1 : 0
         let min: String = "\(convertInt/60)".count == 1 ? "0\(convertInt/60):" : "\(convertInt/60):"
@@ -80,11 +73,8 @@ final class PlayState: ObservableObject {
     }
 
     private func play() {
-        guard let nowPlayingSong = self.nowPlayingSong else { return }
-        if self.currentSong != nowPlayingSong { // 값이 다를경우
-            self.currentSong = nowPlayingSong // 곡 을 변경 후
-            self.youTubePlayer.load(source: .url(nowPlayingSong.url)) // 바로 load
-        }
+        guard let currentSong = currentSong else { return }
+        self.youTubePlayer.load(source: .url(currentSong.url)) // 바로 load
     }
 
     private func uniqueIndex(of item: SimpleSong) -> Int {

--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -59,27 +59,14 @@ final class PlayState: ObservableObject {
         play()
     }
 
-    private func play() {
+    func play() {
         guard let currentSong = currentSong else { return }
         self.youTubePlayer.load(source: .url(currentSong.url)) // 바로 load
     }
 
-    private func uniqueIndex(of item: SimpleSong) -> Int? {
-        // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
-        let index = playList.list.enumerated().compactMap { $0.element == item ? $0.offset : nil }.first
-        return index
-    }
-
-    func uniqueAppend(item: SimpleSong) {
-        let uniqueIndex = uniqueIndex(of: item)
-
-        if let uniqueIndex = uniqueIndex {
-            self.playList.currentPlayIndex = uniqueIndex
-        } else { // 재생 목록에 없으면
-            self.playList.append(item) // 재생목록에 추가
-            self.playList.currentPlayIndex = self.playList.lastIndex // index를 가장 마지막으로 옮김
-        }
+    func play(at item: SimpleSong?) {
         currentSong = item
+        play()
     }
 
 }
@@ -111,6 +98,23 @@ extension PlayState {
 
         func contains(_ item: SimpleSong) -> Bool {
             return list.contains(item)
+        }
+
+        func uniqueAppend(item: SimpleSong) {
+            let uniqueIndex = uniqueIndex(of: item)
+
+            if let uniqueIndex = uniqueIndex {
+                self.currentPlayIndex = uniqueIndex
+            } else { // 재생 목록에 없으면
+                list.append(item) // 재생목록에 추가
+                self.currentPlayIndex = self.lastIndex // index를 가장 마지막으로 옮김
+            }
+        }
+
+        private func uniqueIndex(of item: SimpleSong) -> Int? {
+            // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
+            let index = list.enumerated().compactMap { $0.element == item ? $0.offset : nil }.first
+            return index
         }
 
     }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -77,26 +77,26 @@ final class PlayState: ObservableObject {
         self.youTubePlayer.load(source: .url(currentSong.url)) // 바로 load
     }
 
-    private func uniqueIndex(of item: SimpleSong) -> Int {
-        // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 -1 리턴
-        let index = playList.list.enumerated().compactMap { $0.element == item ? $0.offset : nil }.first ?? -1
+    private func uniqueIndex(of item: SimpleSong) -> Int? {
+        // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
+        let index = playList.list.enumerated().compactMap { $0.element == item ? $0.offset : nil }.first
         return index
     }
 
     func uniqueAppend(item: SimpleSong) {
-
         let uniqueIndex = uniqueIndex(of: item)
-        if uniqueIndex == -1 { // 재생목록에 없으면
-            self.playList.append(item) // 재생목록에 추가
-            self.playList.currentPlayIndex = self.playList.count - 1 // index를 가장 마지막으로 옮김
-        } else {
+
+        if let uniqueIndex = uniqueIndex {
             self.playList.currentPlayIndex = uniqueIndex
+        } else { // 재생 목록에 없으면
+            self.playList.append(item) // 재생목록에 추가
+            self.playList.currentPlayIndex = self.playList.lastIndex // index를 가장 마지막으로 옮김
         }
         currentSong = item
     }
 
     func appendList(item: SimpleSong) {
-        if uniqueIndex(of: item) == -1 { // 재생목록에 없으면
+        if !playList.contains(item) { // 재생목록에 없으면
             self.playList.append(item) // 재생목록에 추가
         }
     }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -13,8 +13,7 @@ final class PlayState: ObservableObject {
 
     static let shared = PlayState()
     @Published var playList = PlayList()
-    @Published var currentProgress: Double = 0
-    @Published var endProgress: Double = 0
+    @Published var progress = PlayProgress()
     @Published var youTubePlayer = YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false))
     @Published var isPlaying: YouTubePlayer.PlaybackState  = .unstarted // 재생상태에 따라 변화
     @Published var currentSong: SimpleSong?
@@ -36,7 +35,7 @@ final class PlayState: ObservableObject {
 
         youTubePlayer.durationPublisher.sink { [weak self] time in
             guard let self = self else { return }
-            self.endProgress = time
+            self.progress.endProgress = time
         }.store(in: &subscription)
     }
 
@@ -120,5 +119,10 @@ extension PlayState {
             return list.contains(item)
         }
 
+    }
+
+    public struct PlayProgress {
+        var currentProgress: Double = 0
+        var endProgress: Double = 0
     }
 }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -82,12 +82,6 @@ final class PlayState: ObservableObject {
         currentSong = item
     }
 
-    func appendList(item: SimpleSong) {
-        if !playList.contains(item) { // 재생목록에 없으면
-            self.playList.append(item) // 재생목록에 추가
-        }
-    }
-
 }
 
 extension PlayState {

--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -21,16 +21,7 @@ final class PlayState: ObservableObject {
 
     var subscription = Set<AnyCancellable>()
 
-    func convertTimetoString(_ dtime: Double) -> String {
-        let convertInt = lround(dtime)-1 >= 0 ? lround(dtime)-1 : 0
-        let min: String = "\(convertInt/60)".count == 1 ? "0\(convertInt/60):" : "\(convertInt/60):"
-        let sec: String = "\(convertInt%60)".count == 1 ? "0\(convertInt%60)" : "\(convertInt%60)"
-
-        return min+sec
-    }
-
     init() {
-        // self.currentPlayIndex = 0
         self.isPlaying = .unstarted
         self.playList = PlayList()
 

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/ArtistView/ArtistScreenView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/ArtistView/ArtistScreenView.swift
@@ -250,8 +250,8 @@ struct ArtistPinnedHeader: View {
                 RoundedRectangleButton(width: ScreenSize.width/2.5, height: ScreenSize.width/15, text: "전체 재생", color: .tabBar, textColor: .primary, imageSource: "play.fill")
                     .onTapGesture {
                         playState.playList.removeAll() // 전부 지운후
-                        playState.playList = castingFromNewSongToSimple(newSongList: chart)  // 현재 해당 chart로 덮어쓰고
-                        playState.currentPlayIndex = 0 // 인덱스 0으로 맞춤
+                        playState.playList.list = castingFromNewSongToSimple(newSongList: chart)  // 현재 해당 chart로 덮어쓰고
+                        playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
                         playState.youTubePlayer.load(source: .url(chart[0].url)) // 첫번째 곡 재생
 
                     }
@@ -261,9 +261,9 @@ struct ArtistPinnedHeader: View {
                     .onTapGesture {
 
                         playState.playList.removeAll() // 전부 지운후
-                        playState.playList = castingFromNewSongToSimple(newSongList: chart) // 현재 해당 chart로 덮어쓰고
-                        shuffle(playlist: &playState.playList)  // 셔플 시킨 후
-                        playState.currentPlayIndex = 0 // 인덱스 0으로 맞춤
+                        playState.playList.list = castingFromNewSongToSimple(newSongList: chart) // 현재 해당 chart로 덮어쓰고
+                        shuffle(playlist: &playState.playList.list)  // 셔플 시킨 후
+                        playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
                         playState.youTubePlayer.load(source: .url(chart[0].url)) // 첫번째 곡 재생
 
                     }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/ArtistView/ArtistScreenView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/ArtistView/ArtistScreenView.swift
@@ -251,9 +251,8 @@ struct ArtistPinnedHeader: View {
                     .onTapGesture {
                         playState.playList.removeAll() // 전부 지운후
                         playState.playList.list = castingFromNewSongToSimple(newSongList: chart)  // 현재 해당 chart로 덮어쓰고
+                        playState.play(at: playState.playList.first) // 첫번째 곡 재생
                         playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
-                        playState.youTubePlayer.load(source: .url(chart[0].url)) // 첫번째 곡 재생
-
                     }
                 Spacer()
 
@@ -263,9 +262,8 @@ struct ArtistPinnedHeader: View {
                         playState.playList.removeAll() // 전부 지운후
                         playState.playList.list = castingFromNewSongToSimple(newSongList: chart) // 현재 해당 chart로 덮어쓰고
                         shuffle(playlist: &playState.playList.list)  // 셔플 시킨 후
+                        playState.play(at: playState.playList.first) // 첫번째 곡 재생
                         playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
-                        playState.youTubePlayer.load(source: .url(chart[0].url)) // 첫번째 곡 재생
-
                     }
                 Spacer()
             }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
@@ -207,9 +207,9 @@ struct PinnedHeaderView: View {
                 RoundedRectangleButton(width: ScreenSize.width/2.5, height: ScreenSize.width/15, text: "전체 재생", color: .tabBar, textColor: .primary, imageSource: "play.fill")
                     .onTapGesture {
                         playState.playList.removeAll() // 전부 지운후
-                        playState.playList = castingFromRankedToSimple(rankedList: chart)  // 현재 해당 chart로 덮어쓰고
+                        playState.playList.list = castingFromRankedToSimple(rankedList: chart)  // 현재 해당 chart로 덮어쓰고
                         playState.youTubePlayer.load(source: .url(chart[0].url)) // 첫번째 곡 재생
-                        playState.currentPlayIndex = 0 // 인덱스 0으로 맞춤
+                        playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
 
                     }
                 Spacer()
@@ -218,9 +218,9 @@ struct PinnedHeaderView: View {
                     .onTapGesture {
 
                         playState.playList.removeAll() // 전부 지운후
-                        playState.playList = castingFromRankedToSimple(rankedList: chart) // 현재 해당 chart로 덮어쓰고
-                        shuffle(playlist: &playState.playList)  // 셔플 시킨 후
-                        playState.currentPlayIndex = 0 // 인덱스 0으로 맞춤
+                        playState.playList.list = castingFromRankedToSimple(rankedList: chart) // 현재 해당 chart로 덮어쓰고
+                        shuffle(playlist: &playState.playList.list)  // 셔플 시킨 후
+                        playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
                         playState.youTubePlayer.load(source: .url(chart[0].url)) // 첫번째 곡 재생
 
                     }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
@@ -208,7 +208,8 @@ struct PinnedHeaderView: View {
                     .onTapGesture {
                         playState.playList.removeAll() // 전부 지운후
                         playState.playList.list = castingFromRankedToSimple(rankedList: chart)  // 현재 해당 chart로 덮어쓰고
-                        playState.youTubePlayer.load(source: .url(chart[0].url)) // 첫번째 곡 재생
+                        playState.currentSong = playState.playList.list.first
+                        playState.youTubePlayer.load(source: .url(playState.currentSong!.url)) // 첫번째 곡 재생
                         playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
 
                     }
@@ -216,12 +217,12 @@ struct PinnedHeaderView: View {
 
                 RoundedRectangleButton(width: ScreenSize.width/2.5, height: ScreenSize.width/15, text: "셔플 재생", color: .tabBar, textColor: .primary, imageSource: "shuffle")
                     .onTapGesture {
-
                         playState.playList.removeAll() // 전부 지운후
                         playState.playList.list = castingFromRankedToSimple(rankedList: chart) // 현재 해당 chart로 덮어쓰고
                         shuffle(playlist: &playState.playList.list)  // 셔플 시킨 후
+                        playState.currentSong = playState.playList.list.first
                         playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
-                        playState.youTubePlayer.load(source: .url(chart[0].url)) // 첫번째 곡 재생
+                        playState.youTubePlayer.load(source: .url(playState.currentSong!.url)) // 첫번째 곡 재생
 
                     }
 

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
@@ -208,10 +208,8 @@ struct PinnedHeaderView: View {
                     .onTapGesture {
                         playState.playList.removeAll() // 전부 지운후
                         playState.playList.list = castingFromRankedToSimple(rankedList: chart)  // 현재 해당 chart로 덮어쓰고
-                        playState.currentSong = playState.playList.list.first
-                        playState.youTubePlayer.load(source: .url(playState.currentSong!.url)) // 첫번째 곡 재생
+                        playState.play(at: playState.playList.first) // 첫번째 곡 재생
                         playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
-
                     }
                 Spacer()
 
@@ -220,10 +218,8 @@ struct PinnedHeaderView: View {
                         playState.playList.removeAll() // 전부 지운후
                         playState.playList.list = castingFromRankedToSimple(rankedList: chart) // 현재 해당 chart로 덮어쓰고
                         shuffle(playlist: &playState.playList.list)  // 셔플 시킨 후
-                        playState.currentSong = playState.playList.list.first
+                        playState.play(at: playState.playList.first) // 첫번째 곡 재생
                         playState.playList.currentPlayIndex = 0 // 인덱스 0으로 맞춤
-                        playState.youTubePlayer.load(source: .url(playState.currentSong!.url)) // 첫번째 곡 재생
-
                     }
 
             }.padding(.horizontal)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/FourRowSongGridView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/FourRowSongGridView.swift
@@ -51,11 +51,8 @@ private extension FourRowSongGridView {
             Button {
                 // FiveRowSong Grid에서는 재생 버튼 누르면 일단 load와 currentSong을 바꿈
                 let simpleSong = SimpleSong(song_id: song.song_id, title: song.title, artist: song.artist, image: song.image, url: song.url)
-                if playState.currentSong != simpleSong {
-                    playState.currentSong =  simpleSong // 강제 배정
-                    playState.youTubePlayer.load(source: .url(simpleSong.url)) // 강제 재생
-                    playState.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
-                }
+                playState.youTubePlayer.load(source: .url(simpleSong.url)) // 강제 재생
+                playState.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
             } label: {
                 ZStack {
 

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/FourRowSongGridView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/FourRowSongGridView.swift
@@ -51,11 +51,10 @@ private extension FourRowSongGridView {
             Button {
                 // FiveRowSong Grid에서는 재생 버튼 누르면 일단 load와 currentSong을 바꿈
                 let simpleSong = SimpleSong(song_id: song.song_id, title: song.title, artist: song.artist, image: song.image, url: song.url)
-                playState.youTubePlayer.load(source: .url(simpleSong.url)) // 강제 재생
-                playState.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
+                playState.play(at: simpleSong)
+                playState.playList.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
             } label: {
                 ZStack {
-
                     HStack {
                         AlbumImageView(url: nowChart[index].image)
                         RankView(now: index+1, last: nowChart[index].last)
@@ -65,7 +64,6 @@ private extension FourRowSongGridView {
                             Text("\(nowChart[index].title)").font(.system(size: 13)).frame(width: 150, alignment: .leading)
                             Text("\(nowChart[index].artist)").font(.system(size: 11)).frame(width: 150, alignment: .leading)
                         }
-
                     }
                 }
             }.accentColor(.primary)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewSongMoreView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewSongMoreView.swift
@@ -76,9 +76,8 @@ extension NewSongMoreView {
                     .cornerRadius(10)
                     .overlay {
                         Button {
-                            playState.currentSong =  simpleSong // 강제 배정
-                            playState.youTubePlayer.load(source: .url(simpleSong.url)) // 강제 재생
-                            playState.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
+                            playState.play(at: simpleSong)
+                            playState.playList.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
                         } label: {
                             Image(systemName: "play.fill")
                                 .resizable()
@@ -95,9 +94,8 @@ extension NewSongMoreView {
                 }.frame(width: width)
 
             }.padding(.vertical, 5).onTapGesture {
-                playState.currentSong =  simpleSong // 강제 배정
-                playState.youTubePlayer.load(source: .url(simpleSong.url)) // 강제 재생
-                playState.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
+                playState.play(at: simpleSong)
+                playState.playList.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
             }
 
         }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewSongOfTheMonth.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewSongOfTheMonth.swift
@@ -62,13 +62,8 @@ extension NewSongOfTheMonthView {
                     .overlay {
                         ZStack {
                             Button {
-
-                                if playState.currentSong != simpleSong {
-                                    playState.currentSong =  simpleSong // 강제 배정
-                                    playState.youTubePlayer.load(source: .url(simpleSong.url)) // 강제 재생
-                                    playState.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
-                                }
-
+                                playState.play(at: simpleSong)
+                                playState.playList.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
                             } label: {
                                 Image(systemName: "play.fill").foregroundColor(.white)
                             }
@@ -84,12 +79,8 @@ extension NewSongOfTheMonthView {
                 }.frame(width: 100)
 
             }.padding().onTapGesture {
-
-                if playState.currentSong != simpleSong {
-                    playState.currentSong =  simpleSong // 강제 배정
-                    playState.youTubePlayer.load(source: .url(simpleSong.url)) // 강제 재생
-                    playState.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
-                }
+                playState.play(at: simpleSong)
+                playState.playList.uniqueAppend(item: simpleSong) // 현재 누른 곡 담기
             }
 
         }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/MainView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/MainView.swift
@@ -52,18 +52,18 @@ struct MainView: View {
                             switch viewModel.currentTab {
                             case .home:
                                 HomeView(musicCart: $musicCart).environmentObject(playState)
-                                    .padding(.bottom, (player.isMiniPlayer&&playState.nowPlayingSong != nil)  ?   tabHeight : 0)
+                                    .padding(.bottom, (player.isMiniPlayer&&playState.currentSong != nil)  ?   tabHeight : 0)
 
                             case .artists:
                                 ArtistScreenView(musicCart: $musicCart).environmentObject(playState)
-                                    .padding(.bottom, (player.isMiniPlayer&&playState.nowPlayingSong != nil)  ?   tabHeight : 0)
+                                    .padding(.bottom, (player.isMiniPlayer&&playState.currentSong != nil)  ?   tabHeight : 0)
                             case .search:
                                 SearchView(musicCart: $musicCart).environmentObject(playState)
-                                    .padding(.bottom, (player.isMiniPlayer&&playState.nowPlayingSong != nil)  ?   tabHeight+10 : 0)
+                                    .padding(.bottom, (player.isMiniPlayer&&playState.currentSong != nil)  ?   tabHeight+10 : 0)
 
                             case .account:
                                 AccountView()
-                                    .padding(.bottom, (player.isMiniPlayer&&playState.nowPlayingSong != nil)  ?  tabHeight : 0)
+                                    .padding(.bottom, (player.isMiniPlayer&&playState.currentSong != nil)  ?  tabHeight : 0)
 
                             }
                         }
@@ -170,7 +170,7 @@ struct MainView: View {
 
                     }
 
-                    if playState.nowPlayingSong != nil {
+                    if playState.currentSong != nil {
                         MiniPlayer(animation: animation)
                             .environmentObject(playState)
                             .environmentObject(player)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/MainView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/MainView.swift
@@ -117,15 +117,17 @@ struct MainView: View {
                                         // 재생 바
                                         Spacer()
                                         Button {
-                                            let simpleSong = musicCart[0]
-                                            playState.currentSong =  simpleSong // 강제 배정
-                                            playState.youTubePlayer.load(source: .url(simpleSong.url)) // 강제 재생
-                                            playState.uniqueAppend(item: simpleSong)
-
-                                            for song in musicCart {
-                                                playState.appendList(item: song)
+                                            // 1. 첫번째 선택 곡 즉시 재생
+                                            let firstSong = musicCart.first!
+                                            playState.currentSong =  firstSong
+                                            playState.youTubePlayer.load(source: .url(firstSong.url))
+                                            
+                                            // 2. 재생목록에 없는 곡들은 재생목록에 추가
+                                            musicCart.forEach { song in
+                                                if !playState.playList.contains(song) {
+                                                    playState.playList.append(song)
+                                                }
                                             }
-
                                             musicCart.removeAll()
 
                                         } label: {
@@ -143,13 +145,13 @@ struct MainView: View {
                                         }
                                         Spacer()
                                         Button {
-
-                                            for song in musicCart {
-                                                playState.appendList(item: song)
+                                            // 재생목록에 없는 곡들은 재생목록에 추가
+                                            musicCart.forEach { song in
+                                                if !playState.playList.contains(song) {
+                                                    playState.playList.append(song)
+                                                }
                                             }
-
                                             musicCart.removeAll()
-
                                         } label: {
                                             ListBarIcon(width: width/5, height: height/28, systemIconName: "plus", text: "담기")
                                         }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/MainView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/MainView.swift
@@ -119,9 +119,8 @@ struct MainView: View {
                                         Button {
                                             // 1. 첫번째 선택 곡 즉시 재생
                                             let firstSong = musicCart.first!
-                                            playState.currentSong =  firstSong
-                                            playState.youTubePlayer.load(source: .url(firstSong.url))
-                                            
+                                            playState.play(at: firstSong)
+
                                             // 2. 재생목록에 없는 곡들은 재생목록에 추가
                                             musicCart.forEach { song in
                                                 if !playState.playList.contains(song) {

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MusicPlayerBar/MiniPlayer.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MusicPlayerBar/MiniPlayer.swift
@@ -25,7 +25,7 @@ struct MiniPlayer: View {
     let hasNotch: Bool = UIDevice.current.hasNotch
 
     var body: some View {
-        if let currentSong = playState.nowPlayingSong {
+        if let currentSong = playState.currentSong {
             VStack(spacing: player.isMiniPlayer ? 0 : nil) {
 
                 // Spacer(minLength: 0)
@@ -48,8 +48,7 @@ struct MiniPlayer: View {
 
                     YoutubeView().environmentObject(playState).frame(maxWidth: player.isMiniPlayer ? miniWidth : player.isPlayerListViewPresented ? 0 : ScreenSize.width, maxHeight: player.isMiniPlayer ? miniHeight : player.isPlayerListViewPresented ? 0 : defaultHeight )
 
-                    if(player.isMiniPlayer) // 미니 플레이어 시 보여질 컨트롤러
-                    {
+                    if player.isMiniPlayer { // 미니 플레이어 시 보여질 컨트롤러
                         VStack(alignment: .leading) { // 리스트 보여주면 .leading
                             Text(currentSong.title)
                                 .modifier(PlayBarTitleModifier())
@@ -64,8 +63,8 @@ struct MiniPlayer: View {
 
                             Image(systemName: "xmark").modifier(PlayBarButtonImageModifier()).onTapGesture {
                                 playState.playList.removeAll()
-                        }
-
+                                playState.currentSong = nil
+                            }
                         }.padding(.horizontal)
 
                     }
@@ -223,15 +222,12 @@ struct ProgressBar: View {
 
     var body: some View {
 
-        if playState.nowPlayingSong != nil {
+        if playState.currentSong != nil {
             VStack {
-
                 // Sldier 설정 및 바인딩
-
                 Slider(value: $playState.currentProgress, in: 0...playState.endProgress) { change in
                     // onEditChanged
-                    if(change == false) // change == true는 slider를 건들기 시작할 때 false는 slider를 내려 놓을 때
-                    {
+                    if change == false { // change == true는 slider를 건들기 시작할 때 false는 slider를 내려 놓을 때
                         playState.youTubePlayer.seek(to: playState.currentProgress, allowSeekAhead: true) // allowSeekAhead = true 서버로 요청
                     }
                 }.onAppear {
@@ -243,14 +239,12 @@ struct ProgressBar: View {
                 }
 
                 HStack {
-
                     Text(playtime).modifier(FullScreenTimeModifer())
                     Spacer()
                     Text(endtime).modifier(FullScreenTimeModifer())
                 }
 
             }.onReceive(timer) { _ in
-
                 playState.youTubePlayer.getCurrentTime { completion in
                     switch completion {
                     case .success(let time):

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MusicPlayerBar/MiniPlayer.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MusicPlayerBar/MiniPlayer.swift
@@ -249,8 +249,8 @@ struct ProgressBar: View {
                     switch completion {
                     case .success(let time):
                         playState.currentProgress = time
-                        playtime = playState.convertTimetoString(time)
-                        endtime = playState.convertTimetoString(playState.endProgress)
+                        playtime = time.convertTimetoString()
+                        endtime = playState.endProgress.convertTimetoString()
 
                     case.failure:
                         print("\(#function) \(#line) Error 발생")

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MusicPlayerBar/MiniPlayer.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MusicPlayerBar/MiniPlayer.swift
@@ -225,10 +225,10 @@ struct ProgressBar: View {
         if playState.currentSong != nil {
             VStack {
                 // Sldier 설정 및 바인딩
-                Slider(value: $playState.currentProgress, in: 0...playState.endProgress) { change in
+                Slider(value: $playState.progress.currentProgress, in: 0...playState.progress.endProgress) { change in
                     // onEditChanged
                     if change == false { // change == true는 slider를 건들기 시작할 때 false는 slider를 내려 놓을 때
-                        playState.youTubePlayer.seek(to: playState.currentProgress, allowSeekAhead: true) // allowSeekAhead = true 서버로 요청
+                        playState.youTubePlayer.seek(to: playState.progress.currentProgress, allowSeekAhead: true) // allowSeekAhead = true 서버로 요청
                     }
                 }.onAppear {
                     // 슬라이더 볼 사이즈 수정
@@ -248,9 +248,9 @@ struct ProgressBar: View {
                 playState.youTubePlayer.getCurrentTime { completion in
                     switch completion {
                     case .success(let time):
-                        playState.currentProgress = time
+                        playState.progress.currentProgress = time
                         playtime = time.convertTimetoString()
-                        endtime = playState.endProgress.convertTimetoString()
+                        endtime = playState.progress.endProgress.convertTimetoString()
 
                     case.failure:
                         print("\(#function) \(#line) Error 발생")

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MusicPlayerBar/PlayListView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MusicPlayerBar/PlayListView.swift
@@ -52,9 +52,9 @@ struct PlayListView: View {
                         .animation(.easeIn, value: playState.currentSong)
 
                         HStack {
-                            TopLeftControlView(playList: $playState.playList, currentIndex: $playState.currentPlayIndex, multipleSelection: $multipleSelection).environmentObject(playState)
+                            TopLeftControlView(playList: $playState.playList.list, currentIndex: $playState.playList.currentPlayIndex, multipleSelection: $multipleSelection).environmentObject(playState)
                             Spacer()
-                            TopRightControlView(playList: $playState.playList, currentIndex: $playState.currentPlayIndex, multipleSelection: $multipleSelection).environmentObject(playState).padding(.trailing, 10)
+                            TopRightControlView(playList: $playState.playList.list, currentIndex: $playState.playList.currentPlayIndex, multipleSelection: $multipleSelection).environmentObject(playState).padding(.trailing, 10)
                         }// .frame(width:width)
 
                     }
@@ -63,7 +63,7 @@ struct PlayListView: View {
                 ScrollView(.vertical, showsIndicators: true) {
                     LazyVStack {
 
-                        ForEach(playState.playList, id: \.self.id) { song in
+                        ForEach(playState.playList.list, id: \.self.id) { song in
 
                             ItemCell(song: song, multipleSelection: $multipleSelection).environmentObject(playState)
 
@@ -75,7 +75,7 @@ struct PlayListView: View {
                                     return NSItemProvider(item: nil, typeIdentifier: song.title)
                                 }
 
-                                .onDrop(of: [song.title], delegate: MyDropDelegate(currentItem: song, currentIndex: $playState.currentPlayIndex, playList: $playState.playList, draggedItem: $draggedItem))
+                                .onDrop(of: [song.title], delegate: MyDropDelegate(currentItem: song, currentIndex: $playState.playList.currentPlayIndex, playList: $playState.playList.list, draggedItem: $draggedItem))
 
                         }
 
@@ -141,7 +141,7 @@ struct ItemCell: View {
         .onTapGesture {
             playState.currentSong = song
             playState.youTubePlayer.load(source: .url(song.url)) // 강제 재생
-            playState.currentPlayIndex = playState.playList.firstIndex(of: song) ?? 0
+            playState.playList.currentPlayIndex = playState.playList.list.firstIndex(of: song) ?? 0
         }
 
     }


### PR DESCRIPTION
# 배경
- 역할이 모호한 메소드들이 많았고, 호출되는 곳이 많아 코드 수정 시 의도하지 않은 동작을 할 여지가 많았습니다.

- 회의 결과 PlayState 는 대부분의 뷰와 맞닿아 있고 Player, 재생목록의 동작에 영향을 미치기에 리팩토링을 최우선으로 진행하기로 결정 하였습니다.


# 작업 내용
- nowPlayingSong 과 currentSong 의 역할이 모호하여, nowPlayingSong을 삭제합니다.

- currentProgress, endProgress 를 PlayProgress 로 통합합니다.

- 통일성을 위해 init 에서 초기화 하던 구문을 제거하고 기본값 지정으로 변경합니다.

- PlayList 클래스를 만들어 재생목록과 관련된 동작은 이곳에서 합니다.

- 기존 뷰에서 노래를 재생시키는 동작을 할때마다 생기는 보일러 플레이트 코드들을 제거하고 play, play(at:) 메소드에 동작을 정의합니다. 

- 익스텐션으로 기능들을 구분짓습니다.