### PR TITLE
⚡ 뷰가 disAppear 될 때, 뷰모델이 deinit 되지 않는 문제를 해결하고, 이미지 다운샘플링을 통해 메모리 사용량을 줄입니다.

### DIFF
--- a/WaktaverseMusic/WaktaverseMusic.xcodeproj/project.pbxproj
+++ b/WaktaverseMusic/WaktaverseMusic.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		7B1D20B928E9969D006F67C6 /* RankView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1D20B828E9969D006F67C6 /* RankView.swift */; };
 		7B1D20BB28E9A6AF006F67C6 /* ChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1D20BA28E9A6AF006F67C6 /* ChartViewModel.swift */; };
 		7B1D20BE28E9A753006F67C6 /* RoundedRectangleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1D20BD28E9A753006F67C6 /* RoundedRectangleButton.swift */; };
+		7B877ABB28F3EA3F0096C025 /* ChartMoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B877ABA28F3EA3F0096C025 /* ChartMoreView.swift */; };
 		D8086D6828BD335600D44F48 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = D8086D6728BD335600D44F48 /* Alamofire */; };
 		D8086D6B28BD335D00D44F48 /* PopupView in Frameworks */ = {isa = PBXBuildFile; productRef = D8086D6A28BD335D00D44F48 /* PopupView */; };
 		D8086D6E28BD336800D44F48 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = D8086D6D28BD336800D44F48 /* Kingfisher */; };
@@ -51,7 +52,6 @@
 		D80F435728E6DD1000C4A485 /* NewSongOfTheMonth.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F431628E6DD1000C4A485 /* NewSongOfTheMonth.swift */; };
 		D80F435828E6DD1000C4A485 /* NewsMoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F431828E6DD1000C4A485 /* NewsMoreView.swift */; };
 		D80F435928E6DD1000C4A485 /* NewSongMoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F431A28E6DD1000C4A485 /* NewSongMoreView.swift */; };
-		D80F435A28E6DD1000C4A485 /* ChartMoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F431C28E6DD1000C4A485 /* ChartMoreView.swift */; };
 		D80F435B28E6DD1000C4A485 /* FourRowSongGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F431D28E6DD1000C4A485 /* FourRowSongGridView.swift */; };
 		D80F435C28E6DD1000C4A485 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F431E28E6DD1000C4A485 /* HomeView.swift */; };
 		D80F435D28E6DD1000C4A485 /* NewsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F431F28E6DD1000C4A485 /* NewsView.swift */; };
@@ -95,6 +95,7 @@
 		7B1D20B828E9969D006F67C6 /* RankView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankView.swift; sourceTree = "<group>"; };
 		7B1D20BA28E9A6AF006F67C6 /* ChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartViewModel.swift; sourceTree = "<group>"; };
 		7B1D20BD28E9A753006F67C6 /* RoundedRectangleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedRectangleButton.swift; sourceTree = "<group>"; };
+		7B877ABA28F3EA3F0096C025 /* ChartMoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartMoreView.swift; sourceTree = "<group>"; };
 		D80F42F528E6DD1000C4A485 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		D80F42F828E6DD1000C4A485 /* WaktaverseMusicApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaktaverseMusicApp.swift; sourceTree = "<group>"; };
 		D80F42F928E6DD1000C4A485 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = ../Assets.xcassets; sourceTree = "<group>"; };
@@ -116,7 +117,6 @@
 		D80F431628E6DD1000C4A485 /* NewSongOfTheMonth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewSongOfTheMonth.swift; sourceTree = "<group>"; };
 		D80F431828E6DD1000C4A485 /* NewsMoreView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsMoreView.swift; sourceTree = "<group>"; };
 		D80F431A28E6DD1000C4A485 /* NewSongMoreView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewSongMoreView.swift; sourceTree = "<group>"; };
-		D80F431C28E6DD1000C4A485 /* ChartMoreView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartMoreView.swift; sourceTree = "<group>"; };
 		D80F431D28E6DD1000C4A485 /* FourRowSongGridView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FourRowSongGridView.swift; sourceTree = "<group>"; };
 		D80F431E28E6DD1000C4A485 /* HomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		D80F431F28E6DD1000C4A485 /* NewsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsView.swift; sourceTree = "<group>"; };
@@ -342,7 +342,7 @@
 				D80F431E28E6DD1000C4A485 /* HomeView.swift */,
 				D80F433028E6DD1000C4A485 /* RadioButtonGroupView.swift */,
 				D80F431D28E6DD1000C4A485 /* FourRowSongGridView.swift */,
-				D80F431C28E6DD1000C4A485 /* ChartMoreView.swift */,
+				7B877ABA28F3EA3F0096C025 /* ChartMoreView.swift */,
 				D80F431628E6DD1000C4A485 /* NewSongOfTheMonth.swift */,
 				D80F431A28E6DD1000C4A485 /* NewSongMoreView.swift */,
 				D80F431F28E6DD1000C4A485 /* NewsView.swift */,
@@ -535,6 +535,7 @@
 				7B1D20AF28E95054006F67C6 /* Const.swift in Sources */,
 				7B1D20A728E94E2B006F67C6 /* ArtistViewModel.swift in Sources */,
 				7B1D20B528E97AE4006F67C6 /* MainViewModel.swift in Sources */,
+				7B877ABB28F3EA3F0096C025 /* ChartMoreView.swift in Sources */,
 				7B1D209628E941D3006F67C6 /* HomeViewModel.swift in Sources */,
 				D80F436028E6DD1000C4A485 /* SettingScreenView.swift in Sources */,
 				D80F434E28E6DD1000C4A485 /* RankedSong.swift in Sources */,
@@ -570,7 +571,6 @@
 				D80F437128E6DD1000C4A485 /* ApiCollections.swift in Sources */,
 				7B1D20A928E94E94006F67C6 /* AccountViewModel.swift in Sources */,
 				D80F436928E6DD1000C4A485 /* PlayerViewModel.swift in Sources */,
-				D80F435A28E6DD1000C4A485 /* ChartMoreView.swift in Sources */,
 				D80F434F28E6DD1000C4A485 /* Artist.swift in Sources */,
 				D80F435828E6DD1000C4A485 /* NewsMoreView.swift in Sources */,
 				D80F434A28E6DD1000C4A485 /* WaktaverseMusic.xcdatamodeld in Sources */,

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 import Combine
 import Kingfisher
 import Foundation
-import ScalingHeaderScrollView
 
 // MARK: 차트 더보기를 눌렀을 때 나오는 뷰 입니다.
 struct ChartMoreView: View {
@@ -21,68 +20,62 @@ struct ChartMoreView: View {
     @State var scrollToTop: Bool = false
     let hasNotch: Bool = UIDevice.current.hasNotch
 
-    // MARK: For Smooth Sliding Effect
-
     var body: some View {
 
-        ZStack(alignment: .topLeading) {
+        ZStack(alignment: .top) {
+            VStack(spacing: 0) {
+                HeaderView()
+                Spacer()
+            } // 이세돌 배경
 
-            ScalingHeaderScrollView {
-                ZStack {
-                    Color.forced
-                    VStack(spacing: hasNotch ? 30 : 30) {
-                        HeaderView()
+            VStack(spacing: 0) {
+                ScrollView {
+                    Spacer(minLength: ScreenSize.height / 6)
+                    LazyVStack(pinnedViews: [.sectionHeaders]) {
+                        Section {
+                            ForEach(viewModel.currentShowCharts.indices, id: \.self) { index in
+                                ChartItemView(rank: index+1, song: viewModel.currentShowCharts[index], musicCart: $musicCart)
+                            }
 
-                        PinnedHeaderView(selectedIndex: $index, chart: $viewModel.currentShowCharts, updateTime: $viewModel.updateTime).environmentObject(playState).coordinateSpace(name: "PinnedHeaderView") // header 위로 올렸을 때 가리기 위함
+                        } header: {
+                            PinnedHeaderView(selectedIndex: $index, chart: $viewModel.currentShowCharts, updateTime: $viewModel.updateTime).environmentObject(playState)
+                                .background(Color.forced) // 필터 ~ 업데이트 시간 부분까지
 
-                    }
-
-                }
-
-            } content: {
-                LazyVStack(spacing: 0) {
-
-                    ForEach(viewModel.currentShowCharts.indices, id: \.self) { index in
-
-                        ChartItemView(rank: index+1, song: viewModel.currentShowCharts[index], musicCart: $musicCart)
-                    }
-
-                }.animation(.ripple(), value: viewModel.currentShowCharts)
-                    .onChange(of: index, perform: { newValue in
-                        switch newValue {
-                        case 0:
-                            viewModel.fetchChart(.total)
-                            viewModel.fetchUpdateTime(.total)
-                        case 1:
-                            viewModel.fetchChart(.hourly)
-                            viewModel.fetchUpdateTime(.hourly)
-
-                        case 2:
-                            viewModel.fetchChart(.daily)
-                            viewModel.fetchUpdateTime(.daily)
-
-                        case 3:
-                            viewModel.fetchChart(.weekly)
-                            viewModel.fetchUpdateTime(.weekly)
-                        case 4:
-                            viewModel.fetchChart(.monthly)
-                            viewModel.fetchUpdateTime(.monthly)
-                        default:
-                            print("Default")
                         }
 
-                        scrollToTop = true
+                    } // LazyVStack
+                    .background(Color.forced) // 차트 아이템 부분
+                    .animation(.ripple(), value: viewModel.currentShowCharts)
+                        .onChange(of: index, perform: { newValue in
+                            switch newValue {
+                            case 0:
+                                viewModel.fetchChart(.total)
+                                viewModel.fetchUpdateTime(.total)
+                            case 1:
+                                viewModel.fetchChart(.hourly)
+                                viewModel.fetchUpdateTime(.hourly)
 
-                    })
+                            case 2:
+                                viewModel.fetchChart(.daily)
+                                viewModel.fetchUpdateTime(.daily)
+
+                            case 3:
+                                viewModel.fetchChart(.weekly)
+                                viewModel.fetchUpdateTime(.weekly)
+                            case 4:
+                                viewModel.fetchChart(.monthly)
+                                viewModel.fetchUpdateTime(.monthly)
+                            default:
+                                print("Default")
+                            }
+
+                            scrollToTop = true
+
+                        })
+                }
             }
-            .height(min: hasNotch ? ScreenSize.height/4 : ScreenSize.height/4, max: hasNotch ? ScreenSize.height/2.5 : ScreenSize.height/2.3)
-            .scrollToTop(resetScroll: $scrollToTop)
-
-            // - MARK: 스크롤
-
             .onAppear(perform: {
                 // 초기에 이전 화면 정보와 같게 하기 위해
-
                 index = Bindingindex
 
                 switch index {
@@ -107,13 +100,13 @@ struct ChartMoreView: View {
                     print("Default")
                 }
             })
-
             .onDisappear(perform: {
                 Bindingindex = index // 닫힐 때 저장된 인덱스 보냄
             })
 
-        }.navigationBarBackButtonHidden(true) // 백 버튼 없애고
-            .navigationBarHidden(true) // Bar 제거
+        } // ZStack
+        .navigationBarBackButtonHidden(true) // 백 버튼 없애고
+        .navigationBarHidden(true) // Bar 제거
         // .ignoresSafeArea(.container,edges:.vertical)
             .padding(1) // safeArea 방지
 
@@ -125,30 +118,26 @@ struct ChartMoreView: View {
                 }
             }))
 
-    }
+    } // body
+
 }
 
 struct HeaderView: View {
-
-    let height = UIScreen.main.bounds.size.height
-
     var body: some View {
 
         Image("mainChartLogo")
             .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(height: height/6)
+            .scaledToFit()
+            // .aspectRatio(contentMode: .fit)
+            .frame(width: ScreenSize.width, height: ScreenSize.height/6)
             .opacity(0.3)
-            .overlay(content: {
-                ZStack(alignment: .center) {
-                    VStack {
-                        // 텍스트 크기를 proxy를 기준으로 변경
-                        Text("BILLBOARDOO CHART").font(.system(size: height/30, weight: .light, design: .default))
-                        Text("HOT 100").font(.custom("GmarketSansTTFBold", size: height/21))
-                    }.padding(.top, 10)
-
+            .overlay(alignment: .center) {
+                VStack {
+                    // 텍스트 크기를 proxy를 기준으로 변경
+                    Text("WAKTAVERSE MUSIC").font(.system(size: ScreenSize.height/30, weight: .light, design: .default))
+                    Text("HOT 100").font(.custom("GmarketSansTTFBold", size: ScreenSize.height/21))
                 }
-            })
+            }
     }
 }
 
@@ -231,7 +220,8 @@ struct PinnedHeaderView: View {
 
             }.padding(.trailing, 5)
         }
-        .frame(height: ScreenSize.height/7)
+        .frame(height: ScreenSize.height/6)
+        .padding(.vertical, 10)
 
     }
 }
@@ -254,9 +244,11 @@ struct ChartItemView: View {
                 .placeholder({
                     Image("placeHolder")
                         .resizable()
-                        .frame(width: 40, height: 40)
+                        .frame(width: 45, height: 45)
                         .transition(.opacity.combined(with: .scale))
                 })
+                // 대부분 500*500 or 480*360 으로 들어옴
+                .downsampling(size: CGSize(width: 200, height: 200)) // 약 절반 사이즈
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 45, height: 45)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/ChartMoreView.swift
@@ -31,7 +31,7 @@ struct ChartMoreView: View {
             VStack(spacing: 0) {
                 ScrollView {
                     Spacer(minLength: ScreenSize.height / 6)
-                    LazyVStack(pinnedViews: [.sectionHeaders]) {
+                    LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                         Section {
                             ForEach(viewModel.currentShowCharts.indices, id: \.self) { index in
                                 ChartItemView(rank: index+1, song: viewModel.currentShowCharts[index], musicCart: $musicCart)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/FourRowSongGridView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/FourRowSongGridView.swift
@@ -91,7 +91,8 @@ struct AlbumImageView: View {
             .onFailure { _ in
 
             }
-
+            // 대부분 500*500 or 480*360 으로 들어옴
+            .downsampling(size: CGSize(width: 200, height: 200)) // 약 절반 사이즈
             .resizable()
             .frame(width: 40, height: 40) // resize
     }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewsMoreView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewsMoreView.swift
@@ -37,10 +37,11 @@ struct NewsMoreView: View {
 
         .navigationTitle("NEWS")
         .navigationBarTitleDisplayMode(.large)
+        .navigationBarBackButtonHidden(true) // 백 버튼 없애고
         .background()
         .highPriorityGesture(DragGesture().onEnded({ value in
-            if(value.translation.width > 100) // 왼 오 드래그가 만족할 때
-            {
+            if value.translation.width > 100 { // 왼 오 드래그가 만족할 때
+                clearCache()
                 self.presentationMode.wrappedValue.dismiss() // 뒤로가기
             }
         })) // 부모 제스쳐가 먼져 ( swipe 하여 나가는게 NavigationLink의 클릭 이벤트 보다 우선)
@@ -58,6 +59,7 @@ extension NewsMoreView {
             } label: {
                 VStack(alignment: .leading, spacing: 5) {
                     KFImage(URL(string: "\(ApiCollections.newsThumbnail)\(data.time).png")!)
+                        .downsampling(size: CGSize(width: 400, height: 200)) // 약 절반 사이즈
                         .resizable()
                         .scaledToFill()
                         .clipped()

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewsView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewsView.swift
@@ -35,7 +35,7 @@ extension NewsView {
 
     var OneGridRow: some View {
 
-        ForEach(viewModel.news, id: \.self.id) { news in
+        ForEach(viewModel.news.prefix(3), id: \.self.id) { news in
 
             NavigationLink {
                 CafeWebView(urlToLoad: "\(ApiCollections.newsCafe)\(news.newsId)")

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/SearchView/SearchView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/SearchView/SearchView.swift
@@ -106,6 +106,7 @@ struct SongListItemView: View {
                         .frame(width: 45, height: 45)
                         .transition(.opacity.combined(with: .scale))
                 })
+                .downsampling(size: CGSize(width: 200, height: 200)) // 약 절반 사이즈
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 45, height: 45)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/ChartViewModel.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/ChartViewModel.swift
@@ -13,6 +13,11 @@ final class ChartViewModel: ObservableObject {
     @Published var updateTime: Int = 0
     var subscription = Set<AnyCancellable>()
 
+    deinit {
+        clearCache()
+        print("❌ ChartViewModel deinit")
+    }
+
     func fetchChart(_ category: TopCategory) {
         Repository.shared.fetchTopRankedSong(category: category).sink { completion in
             switch completion {

--- a/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/HomeViewModel.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/HomeViewModel.swift
@@ -41,7 +41,7 @@ final class HomeViewModel: ObservableObject {
         fetchNewSong()
         fetchNews()
     }
-    
+
     deinit {
         clearCache()
         print("❌ HomeViewModel deinit")

--- a/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/HomeViewModel.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/HomeViewModel.swift
@@ -41,6 +41,11 @@ final class HomeViewModel: ObservableObject {
         fetchNewSong()
         fetchNews()
     }
+    
+    deinit {
+        clearCache()
+        print("❌ HomeViewModel deinit")
+    }
 
     func fetchTop20(category: TopCategory) {
         Repository.shared.fetchTopRankedSong(category: category, limit: 20)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/SearchViewModel.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/SearchViewModel.swift
@@ -24,6 +24,11 @@ final class SearchViewModel: ObservableObject {
             .assign(to: &$debouncedValue)
     }
 
+    deinit {
+        clearCache()
+        print("❌ SearchViewModel deinit")
+    }
+    
     func fetchSong(_ keyword: String) {
         Repository.shared.fetchSearchWithKeyword(keyword)
             .sink { (_) in

--- a/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/SearchViewModel.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/SearchViewModel.swift
@@ -28,7 +28,7 @@ final class SearchViewModel: ObservableObject {
         clearCache()
         print("❌ SearchViewModel deinit")
     }
-    
+
     func fetchSong(_ keyword: String) {
         Repository.shared.fetchSearchWithKeyword(keyword)
             .sink { (_) in

--- a/WaktaverseMusic/WaktaverseMusic/WaktaverseMusicApp.swift
+++ b/WaktaverseMusic/WaktaverseMusic/WaktaverseMusicApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UIKit
 import Foundation
 import AVFoundation
+import Kingfisher
 
 @main
 struct WaktaverseMusicApp: App {
@@ -44,4 +45,8 @@ func changeMode(isDarkMode: Bool) {
             window.overrideUserInterfaceStyle = .light
         }
     }
+}
+
+func clearCache() {
+    ImageCache.default.clearCache()
 }


### PR DESCRIPTION
### 관련 이슈  #7

### 배경

- StickyHeader를 구현하기 위해 사용했던 오픈소스 라이브러리 ScalingHeaderScrollView 로 인해 뷰가 disAppear 되어도 뷰모델이 deinit 되지 않아 메모리에 계속 쌓이는 문제가 있었습니다.

- 서버로부터 받아오는 이미지의 사이즈가 앱에서 사용하는 사이즈보다 커 메모리가 낭비되는 문제가 있었습니다.

- 회의 결과 캐시를 비워주는 코드가 없어 추후에 의도치 않은 버그가 생길 것으로 우려되었습니다.

### 작업 내용

- ChartMoreView 에 있는 ScalingHeaderScrollView 를 제거하고 LazyVStack(pinnedViews: )를 활용해 직접 구현한 버전으로 변경하였습니다.

- .downsampling(size: ) 메소드로 앨범아트 등을 받아오는 부분에 적용해 메모리를 약 5배 가까이 줄였습니다. (100곡 정도 불러왔을 때, 약 500MB -> 약 100MB)

- ImageCache.default.clearCache() 메소드로 뷰모델 deinit 시 캐시를 비워주는 코드를 추가하였습니다.