### PR TITLE
⚡  ArtistPinnedHeader dynamic island 대응

### DIFF
--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/ArtistView/ArtistView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/ArtistView/ArtistView.swift
@@ -178,8 +178,9 @@ struct ArtistPinnedHeader: View {
 
     var body: some View {
 
-        VStack(alignment: .leading, spacing: hasNotch ? 30 :10) {
-
+        VStack(alignment: .leading, spacing: 10) {
+            Spacer()
+                .frame(height: 1)
             HStack(spacing: 5) {
                 ForEach(sorting.indices, id: \.self) { idx in
 


### PR DESCRIPTION
ArtistPinnedHeader가 dynamic island에서 잘리는 문제가 발생하였습니다. 
 Safe Area를 이용하여 버그를 수정하였습니다.