### PR TITLE
⚡ API 변경에 따른 코드를 수정하고, NewsMoreView의 뉴스 목록을 무한 스크롤 방식으로 불러옵니다.

### DIFF
--- a/WaktaverseMusic/WaktaverseMusic.xcodeproj/project.pbxproj
+++ b/WaktaverseMusic/WaktaverseMusic.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		7B1D20BB28E9A6AF006F67C6 /* ChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1D20BA28E9A6AF006F67C6 /* ChartViewModel.swift */; };
 		7B1D20BE28E9A753006F67C6 /* RoundedRectangleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1D20BD28E9A753006F67C6 /* RoundedRectangleButton.swift */; };
 		7B877ABB28F3EA3F0096C025 /* ChartMoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B877ABA28F3EA3F0096C025 /* ChartMoreView.swift */; };
+		7BB32D6D28FF7EA900AFB097 /* NewsMoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB32D6C28FF7EA900AFB097 /* NewsMoreViewModel.swift */; };
 		D8086D6828BD335600D44F48 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = D8086D6728BD335600D44F48 /* Alamofire */; };
 		D8086D6B28BD335D00D44F48 /* PopupView in Frameworks */ = {isa = PBXBuildFile; productRef = D8086D6A28BD335D00D44F48 /* PopupView */; };
 		D8086D6E28BD336800D44F48 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = D8086D6D28BD336800D44F48 /* Kingfisher */; };
@@ -100,6 +101,7 @@
 		7B1D20BA28E9A6AF006F67C6 /* ChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartViewModel.swift; sourceTree = "<group>"; };
 		7B1D20BD28E9A753006F67C6 /* RoundedRectangleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedRectangleButton.swift; sourceTree = "<group>"; };
 		7B877ABA28F3EA3F0096C025 /* ChartMoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartMoreView.swift; sourceTree = "<group>"; };
+		7BB32D6C28FF7EA900AFB097 /* NewsMoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsMoreViewModel.swift; sourceTree = "<group>"; };
 		D80F42F528E6DD1000C4A485 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		D80F42F828E6DD1000C4A485 /* WaktaverseMusicApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaktaverseMusicApp.swift; sourceTree = "<group>"; };
 		D80F42F928E6DD1000C4A485 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = ../Assets.xcassets; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				7B1D20A828E94E94006F67C6 /* AccountViewModel.swift */,
 				7B1D20AA28E94EA8006F67C6 /* NetoworkViewModel.swift */,
 				D80F433328E6DD1000C4A485 /* PlayerViewModel.swift */,
+				7BB32D6C28FF7EA900AFB097 /* NewsMoreViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -609,6 +612,7 @@
 				D80F434228E6DD1000C4A485 /* Extensions.swift in Sources */,
 				D80F434628E6DD1000C4A485 /* PlayState.swift in Sources */,
 				D80F435D28E6DD1000C4A485 /* NewsView.swift in Sources */,
+				7BB32D6D28FF7EA900AFB097 /* NewsMoreViewModel.swift in Sources */,
 				D80F435528E6DD1000C4A485 /* NetworkView.swift in Sources */,
 				D80F435928E6DD1000C4A485 /* NewSongMoreView.swift in Sources */,
 				D80F435128E6DD1000C4A485 /* LaunchScreenView.swift in Sources */,

--- a/WaktaverseMusic/WaktaverseMusic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WaktaverseMusic/WaktaverseMusic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
         "branch" : "master",
-        "revision" : "bdecb2c87a21a236dcfe88b21532ad3f0e3d20f4"
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b"
       }
     },
     {
@@ -87,7 +87,7 @@
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
         "branch" : "master",
-        "revision" : "dffcc081c411bb34267297962666e2e21cd45b0d"
+        "revision" : "26a5aee988318f1a57adc9b9c3e676ce318630a8"
       }
     },
     {
@@ -114,7 +114,7 @@
       "location" : "https://github.com/exyte/PopupView.git",
       "state" : {
         "branch" : "master",
-        "revision" : "3c82a7d09ba44e1c7d8a2f7d17657de2e03d0f24"
+        "revision" : "3122129fba0f5501e1f59161db3210282efd2cea"
       }
     },
     {

--- a/WaktaverseMusic/WaktaverseMusic/Sources/Repository/Repository.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/Repository/Repository.swift
@@ -65,12 +65,17 @@ class Repository {
     }
 
     /// 뉴스 정보를 불러옵니다.
+    /// - Parameter start: 몇번째 뉴스부터 불러올건지
     /// - Returns: [NewsModel]
-    func fetchNews() -> AnyPublisher<[NewsModel], Error> {
-        let url = ApiCollections.news
+    func fetchNews(start: Int) -> AnyPublisher<[NewsModel], Error> {
+        let url = Const.URL.base + Const.URL.api + Const.URL.news
         print(url)
-
-        return AF.request(url)
+        
+        let params: Parameters = [
+            "start": start
+        ]
+        
+        return AF.request(url, parameters: params)
             .validate(statusCode: 200..<300)
             .publishDecodable(type: [NewsModel].self)
             .value()

--- a/WaktaverseMusic/WaktaverseMusic/Sources/Repository/Repository.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/Repository/Repository.swift
@@ -70,11 +70,11 @@ class Repository {
     func fetchNews(start: Int) -> AnyPublisher<[NewsModel], Error> {
         let url = Const.URL.base + Const.URL.api + Const.URL.news
         print(url)
-        
+
         let params: Parameters = [
             "start": start
         ]
-        
+
         return AF.request(url, parameters: params)
             .validate(statusCode: 200..<300)
             .publishDecodable(type: [NewsModel].self)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/HeaderViews.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/HeaderViews.swift
@@ -78,7 +78,7 @@ struct NewsHeader: View {
                 Spacer()
 
                 NavigationLink {
-                    NewsMoreView(news: $news)
+                    NewsMoreView()
                 } label: {
                     Text("더보기").foregroundColor(.gray)
                 }

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewsMoreView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/HomeView/NewsMoreView.swift
@@ -13,7 +13,7 @@ import Kingfisher
 struct NewsMoreView: View {
 
     @EnvironmentObject var playState: PlayState
-    @Binding var news: [NewsModel]
+    @StateObject var viewModel = NewsMoreViewModel()
     let columns: [GridItem] = Array(repeating: GridItem(.flexible()), count: Int(UIScreen.main.bounds.width)/180)
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode> // 스와이프하여 뒤로가기를 위해
 
@@ -51,13 +51,14 @@ struct NewsMoreView: View {
 extension NewsMoreView {
     var ThreeColumnsGrid: some View {
 
-        ForEach(news, id: \.self.id) { data in
+        ForEach(viewModel.news.indices, id: \.self) { index in
+            let item = viewModel.news[index]
 
             NavigationLink {
-                CafeWebView(urlToLoad: "\(ApiCollections.newsCafe)\(data.newsId)")
+                CafeWebView(urlToLoad: "\(ApiCollections.newsCafe)\(item.newsId)")
             } label: {
                 VStack(alignment: .leading, spacing: 5) {
-                    KFImage(URL(string: "\(Const.URL.base)\(Const.URL.static)\(Const.URL.news)/\(data.time).png")!)
+                    KFImage(URL(string: "\(Const.URL.base)\(Const.URL.static)\(Const.URL.news)/\(item.time).png")!)
                         .downsampling(size: CGSize(width: 400, height: 200)) // 약 절반 사이즈
                         .resizable()
                         .scaledToFill()
@@ -65,7 +66,14 @@ extension NewsMoreView {
                         .frame(width: 180, height: 120, alignment: .center)
                         .cornerRadius(10)
                         .shadow(color: .black.opacity(0.8), radius: 10, x: 0, y: 0)
-                    Text(data.title.replacingOccurrences(of: "이세돌포커스 -", with: "")).font(.system(size: 15, weight: .semibold, design: .default)).lineLimit(1)
+                        .onAppear {
+                            // 마지막 뉴스가 보여질 때 다음 30개를 불러옴
+                            print(index, viewModel.news.count)
+                            if index == viewModel.news.count - 1 {
+                                viewModel.fetchNews()
+                            }
+                        }
+                    Text(item.title.replacingOccurrences(of: "이세돌포커스 -", with: "")).font(.system(size: 15, weight: .semibold, design: .default)).lineLimit(1)
 
                 }
             }.frame(width: 180)

--- a/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/HomeViewModel.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/HomeViewModel.swift
@@ -83,7 +83,7 @@ final class HomeViewModel: ObservableObject {
     }
 
     func fetchNews() {
-        Repository.shared.fetchNews().sink { (_) in
+        Repository.shared.fetchNews(start: 0).sink { (_) in
 
         } receiveValue: { [weak self] (data: [NewsModel]) in
             guard let self = self else {return}

--- a/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/NewsMoreViewModel.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/ViewModel/NewsMoreViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  NewsMoreViewModel.swift
+//  WaktaverseMusic
+//
+//  Created by YoungK on 2022/10/19.
+//
+
+import Foundation
+import Combine
+
+final class NewsMoreViewModel: ObservableObject {
+    @Published var news: [NewsModel] = [NewsModel]()
+
+    var subscription = Set<AnyCancellable>()
+
+    init() {
+        fetchNews()
+    }
+
+    deinit {
+        print("❌ NewsMoreViewModel deinit")
+    }
+
+    func fetchNews() {
+        Repository.shared.fetchNews(start: news.count).sink { (_) in
+
+        } receiveValue: { [weak self] (data: [NewsModel]) in
+            guard let self = self else {return}
+            _ = data.map { self.news.append($0) }
+
+        }.store(in: &subscription)
+    }
+}


### PR DESCRIPTION
### 배경
HomeView, NewsMoreView에서 사용되는 fetchNews의 api 가 변경되었습니다.

### 작업내용
- fetchNews의 url이 변경되고 파라미터가 추가되었습니다.
- NewsMoreView의 뉴스 목록을 무한 스크롤 방식으로 불러옵니다.
- NewsMoreView 처음 진입 시 30개를 불러오고, 이후론 가장 마지막 뉴스가 onAppear 될때 그 다음 30개를 불러옵니다.