### PR TITLE
⚡ 백그라운드 진입 시, 재생 중이던 플레이어를 이어서 재생합니다.

### DIFF
--- a/WaktaverseMusic/WaktaverseMusic/WaktaverseMusicApp.swift
+++ b/WaktaverseMusic/WaktaverseMusic/WaktaverseMusicApp.swift
@@ -22,7 +22,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
 @main
 struct WaktaverseMusicApp: App {
-
+    @Environment(\.scenePhase) var scenePhase
     @AppStorage("isDarkMode") var isDarkMode: Bool = UserDefaults.standard.bool(forKey: "isDarkMode")
 
     var playState = PlayState.shared
@@ -38,7 +38,14 @@ struct WaktaverseMusicApp: App {
                 // 네트워크 등록
             }
 
-        }
+        }.onChange(of: scenePhase) { newScenePhase in
+            if newScenePhase == .background {
+                  let isPlayed = playState.isPlaying
+                  DispatchQueue.main.asyncAfter(deadline: .now()+0.5, execute: {
+                      if isPlayed == .playing {playState.youTubePlayer.play()}
+                  })
+            }
+          }
     }
 
 }


### PR DESCRIPTION
### 배경
- 백그라운드 재생에 대한 사용자들의 니즈가 많았습니다.

### 작업 내용
- ScenePhase가 background 될 때, 사용자의 재생/일시정지 상태에 따라 백그라운드에서 재생되도록 합니다.

### 실행 영상(소리주의)
https://user-images.githubusercontent.com/60254939/197167067-d3288e16-ce46-4330-89e9-c2074ebb8cba.mov

