### PR TITLE
⚡ userdefaults 내 currentPlayList와 lastPlayedSong 데이터 삭제 방식을 변경합니다.

### DIFF
--- a/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/PlayState/PlayState.swift
@@ -42,23 +42,32 @@ final class PlayState: ObservableObject {
             guard let self = self else { return }
             self.progress.endProgress = time
         }.store(in: &subscription)
+    }
 
+    func subscribePlayList() {
         playList.$list.sink { list in
             if !list.isEmpty {
                 let encodedPlayList = list.map { try? JSONEncoder().encode($0) }
                 print("✅ \(encodedPlayList.count) 개의 곡을 key: currentPlayList 에 저장합니다.")
                 UserDefaults.standard.set(encodedPlayList, forKey: "currentPlayList")
+            } else {
+                print("✅ key: currentPlayList에 저장된 데이터를 제거합니다.")
+                UserDefaults.standard.set(nil, forKey: "currentPlayList")
             }
         }.store(in: &subscription)
+    }
 
+    func subscribeCurrentSong() {
         $currentSong.sink { song in
             if let song {
                 let encodedSong = try? JSONEncoder().encode(song)
                 print("✅ \(song.title) 곡을 key: lastPlayedSong 에 저장합니다.")
                 UserDefaults.standard.set(encodedSong, forKey: "lastPlayedSong")
+            } else {
+                print("✅ key: lastPlayedSong에 저장된 데이터를 제거합니다.")
+                UserDefaults.standard.set(nil, forKey: "lastPlayedSong")
             }
         }.store(in: &subscription)
-
     }
 
 }
@@ -124,10 +133,6 @@ extension PlayState {
 
         func removeAll() {
             list.removeAll()
-            print("✅ key: currentPlayList에 저장된 데이터를 제거합니다.")
-            UserDefaults.standard.set(nil, forKey: "currentPlayList")
-            print("✅ key: lastPlayedSong에 저장된 데이터를 제거합니다.")
-            UserDefaults.standard.set(nil, forKey: "lastPlayedSong")
         }
 
         func contains(_ item: SimpleSong) -> Bool {

--- a/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/MainView.swift
+++ b/WaktaverseMusic/WaktaverseMusic/Sources/View/MainView/MainView.swift
@@ -32,6 +32,7 @@ struct MainView: View {
 
         if isLoading {
             LaunchScreenView().onAppear {
+                // 1. 유저디폴트에서 불러오기
                 let playList: [SimpleSong] = viewModel.loadToCurrentPlayList()
                 let lastPlayedSong: SimpleSong? = viewModel.loadToLastPlayedSong()
 
@@ -42,12 +43,16 @@ struct MainView: View {
                     playState.playList.list = playList
                     playState.currentSong = lastPlayedSong ?? playList.first
 
-                    // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
-                    let index: Int? = playList.enumerated().compactMap { $0.element == lastPlayedSong ? $0.offset : nil }.first
-                    playState.playList.currentPlayIndex = index ?? 0 // 예상치못한 오류로 index 가 nil 이면 0번째로
+                    // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 0 리턴
+                    let index: Int = playList.enumerated().compactMap { $0.element == lastPlayedSong ? $0.offset : nil }.first ?? 0
+                    playState.playList.currentPlayIndex = index
 
                     playState.youTubePlayer.cue(source: .url(playState.currentSong!.song_id.youtube()))
                 }
+                
+                // 2. 불러온 다음 구독
+                playState.subscribePlayList()
+                playState.subscribeCurrentSong()
 
                 DispatchQueue.main.asyncAfter(deadline: .now()+2) {
                     withAnimation { isLoading.toggle() }


### PR DESCRIPTION
### 배경
- userdefaults 관련 작업을 removeAll() 메소드에서 계속하면 추후에 userdefaults에 저장하는 데이터가 많아졌을때 복잡해질 것으로 예상하여 리팩토링을 고민하였습니다.

### 작업내용
- 기존 removeAll() 메소드에 의존하던 방식에서 playList와 currentSong를 구독해 변화가 일어날때 추가 또는 삭제하는 방식으로 변경
- userdefaults 내 데이터를 불러온다음 구독하도록 하였습니다.
  -  **순서주의**: PlayState init 시에 바로 구독하면, playList 가 초기화되어 비어있기때문에 userdefaults 내 데이터를 삭제하게 됩니다.